### PR TITLE
Empty prompt on passing empty string, and shortcut to clear screen

### DIFF
--- a/js/resume.js
+++ b/js/resume.js
@@ -59,6 +59,9 @@ cmd.addEventListener("keyup", function (event) {
 	} else if ((event.keyCode === 32 && event.ctrlKey)) {
 		event.preventDefault();
 		tab_completion();
+	} else if (event.keyCode === 76 && event.ctrlKey) {	// ctrl + l pressed
+		var element = document.getElementById("executed_commands");
+		element.innerHTML = "";
 	}
 });
 
@@ -146,11 +149,15 @@ function run_command() {
 	cmd_output.appendChild(container);
 	container.innerHTML = `<span style = "color:green">➜</span>
     <span style = "color:cyan">[jai@root]</span> ` + input;
-	cmd_output.appendChild(output);
-	cmd_list.push(input);
+	if(output !== undefined){
+	// only if user has typed some command, add it to list of executed commands
+		cmd_output.appendChild(output);
+		cmd_list.push(input);
+	}
 
 	var element = document.getElementById("executed_commands");
-	element.appendChild(cmd_output);
+	element.appendChild(cmd_output);	// this would now add an empty prompt
+	// if user just pressed enter without typing any command
 
 	cmd.value = "";
 	cmd_index = cmd_list.length - 1;


### PR DESCRIPTION
Currently, when user presses enter without typing anything, console gives up error because we are trying to add output which is undefined
as a Node inside another node, so changed it to add this only when user has pressed something, and instead add an empty prompt
in case of empty input just like normal bash shells

Also, added feature to allow clearing up screen when user presses "ctrl + l" key combination to avoid unncessary clutter.

Attaching a screenshot of empty command problem, and what current version does to resolve it

<img width="1440" alt="current_version" src="https://user-images.githubusercontent.com/32142363/118777745-0651b780-b8a7-11eb-9a74-59791f61bad8.png">

<img width="1440" alt="modified_version" src="https://user-images.githubusercontent.com/32142363/118777732-02259a00-b8a7-11eb-9f90-a3e7f40f130e.png">

The top shows errors that come up in current version, and bottom image shows that we now have empty prompts displayed instead and no errors in console